### PR TITLE
Code fixes:

### DIFF
--- a/flr.erb
+++ b/flr.erb
@@ -12,13 +12,6 @@ end
 
 meta = YAML.load_file('rules/meta')
 
-def word_wrap(text, options = {})
-  line_width = options.fetch(:line_width, 80)
-
-  text.split("\n").collect! do |line|
-    line.length > line_width ? line.gsub(/(.{1,#{line_width}})(\s+|$)/, "\\1\n").strip : line
-  end * "\n"
-end
 %>THE FULL LOGICAL RULESET
 
 Most Recent Ruleset Change Recorded:
@@ -44,7 +37,7 @@ Rule <%=rule.id%>/<%=get_rev(rule)%> (Power=<%=rule.power%>)
 %>
 
 History:
-<%= get_history(rule).join("\n") %>
+<%= word_wrap(get_history(rule).join("\n"), {indent: 2}) %>
 
 ----------------------------------------------------------------------
 <% end %><%end%>

--- a/html.erb
+++ b/html.erb
@@ -27,14 +27,6 @@ def linkify(text, keywords)
   t
 end
 
-def word_wrap(text, options = {})
-  line_width = options.fetch(:line_width, 80)
-
-  text.split("\n").collect! do |line|
-    line.length > line_width ? line.gsub(/(.{1,#{line_width}})(\s+|$)/, "\\1\n").strip : line
-  end * "\n"
-end
-
 markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
 %>
 


### PR DESCRIPTION
- Move word_wrap to common.rb.
- Change word_wrap to allow (and properly handle) a trailing indent, as
is used for rule annotations.
- And change the default wrap to 70, which is supposed to be used for
the ruleset for some reason lost to memory.
- Actually use word_wrap when formatting annotations.
- Replace underscores with spaces in all fields, not just proposal
titles (fixes things like 'Retitled from "Reward_and_Delay" by
proposal', or spaces in player names).